### PR TITLE
IO::Socket::INET is builtin now

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,9 +6,7 @@
   "provides" : {
     "Growl::GNTP" : "lib/Growl/GNTP.pm6"
   },
-  "depends" : [
-    "IO::Socket::INET"
-  ],
+  "depends" : [],
   "description" : "Perl6 implementation of GNTP Protocol (Client Part)",
   "version" : "*",
   "authors" : [


### PR DESCRIPTION
So the module can be installed by other users.